### PR TITLE
Fix Scroll issue with YouTube embeds

### DIFF
--- a/src/css/visualizationView.sass
+++ b/src/css/visualizationView.sass
@@ -4,7 +4,7 @@
   flex-direction: column
   min-height: 100%;
   font-family: $family-sans
-  iframe
+  iframe.visualization-runner
     position: absolute
   .visualization-view-body
     flex: 1

--- a/src/visualizationRunner/runnerIframe.js
+++ b/src/visualizationRunner/runnerIframe.js
@@ -23,6 +23,7 @@ export class RunnerIFrame extends Component {
     const { width, height, scale } = this.props;
     return (
       <iframe
+        className='visualization-runner'
         ref={this.iFrameRef}
         width={width}
         height={height}


### PR DESCRIPTION
Fixes an issue where the licence info could not be scrolled into view, as our CSS was accidentally selecting the YouTube iframe and applying styles that should belong only to the visualization runner iframe.